### PR TITLE
Simd-based horizontal maximum (for float)

### DIFF
--- a/Intrinsics/ArrayIntrinsics/Max.float.cs
+++ b/Intrinsics/ArrayIntrinsics/Max.float.cs
@@ -1,0 +1,74 @@
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace IntrinsicsPlayground
+{
+    unsafe partial class ArrayIntrinsics
+    {
+        public static float Max_Avx(float[] array)
+        {
+            if (array.Length == 0)
+                return 0;
+
+            const int vecSize = 8;
+
+            if (array.Length < vecSize)
+                return Max_Soft(array, 0, float.MinValue);
+
+            int i = 0;
+            Vector256<float> max = Avx.SetAllVector256(float.MinValue);
+            fixed (float* ptr = &array[0])
+            {
+                for (; i <= array.Length - vecSize; i += vecSize) //16 for AVX512
+                {
+                    var current = Avx.LoadVector256(ptr + i);
+                    max = Avx.Max(current, max);
+                }
+            }
+
+            float finalMax = ReduceMax(max);
+
+            if (i < array.Length - 1)
+                finalMax = Max_Soft(array, i, finalMax);
+
+            return finalMax;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static float Max_Soft(float[] array, int offset, float initialMax) // for small chunks
+        {
+            float max = initialMax;
+            for (; offset < array.Length; offset++)
+            {
+                var item = array[offset];
+                if (item > max)
+                    max = item;
+            }
+            return max;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static float ReduceMax(Vector256<float> vector)
+        {
+            Vector128<float> hi128 = Avx.ExtractVector128(vector, 1);
+            Vector128<float> lo128 = Avx.ExtractVector128(vector, 0);
+
+            Vector128<float> hiTmp1 = Avx.Permute(hi128, 0x1b);
+            Vector128<float> hiTmp2 = Avx.Permute(hi128, 0x4e);
+
+            Vector128<float> loTmp1 = Avx.Permute(lo128, 0x1b);
+            Vector128<float> loTmp2 = Avx.Permute(lo128, 0x4e);
+
+            hi128 = Sse.Max(hi128, hiTmp1);
+            hi128 = Sse.Max(hi128, hiTmp2);
+
+            lo128 = Sse.Max(lo128, loTmp1);
+            lo128 = Sse.Max(lo128, loTmp2);
+
+            lo128 = Sse.Max(lo128, hi128);
+
+            return Sse.ConvertToSingle(lo128);
+        }
+    }
+}

--- a/Tests/ArrayIntrinsicsTests.cs
+++ b/Tests/ArrayIntrinsicsTests.cs
@@ -100,6 +100,20 @@ namespace IntrinsicsPlayground.Tests
         }
 
         [Fact]
+        public void ArrayIntrinsics_Max_float()
+        {
+            for (int i = 2; i < 1024; i++)
+            {
+                var array = Enumerable.Range(0, i).Concat(Enumerable.Range(0, i).Reverse()).Select(t => (float)t).ToArray(); // 0 1 2 3 2 1 0 (for i==4)
+
+                var expected = array.Max();
+                var actual = ArrayIntrinsics.Max_Avx(array);
+
+                Assert.Equal(expected, actual);
+            }
+        }
+
+        [Fact]
         public void ArrayIntrinsics_Sum()
         {
             for (int i = 0; i < 1024; i++)


### PR DESCRIPTION
https://github.com/EgorBo/IntrinsicsPlayground/blob/caedf0624e817418b4d0cf8f948c5feb815fb625/Intrinsics/ArrayIntrinsics/Max.cs#L31-L32

Well there's a way, but not really straightforward. You need to permute ("rotate") the elements, to get pairwise-comparisons. See `ReduceMax`-method.

For `int` there may be same awkward ways via `Permute2x128` and that like, but I didn't pursue this. Normally I just need the `double`-variants, and they are quite "easy" to permute. So this in adoption to `float`.

The produced asm looks quite nice:
```asm
G_M62377_IG02:
    C4E37D19C101    vextractf128 ymm1, ymm0, 1
    C4E37904D11B    vpermilps    xmm2, xmm1, 27
    C4E37904D94E    vpermilps    xmm3, xmm1, 78
    C4E37D19C000    vextractf128 ymm0, ymm0, 0
    C4E37904E01B    vpermilps    xmm4, xmm0, 27
    C4E37904E84E    vpermilps    xmm5, xmm0, 78
    C4E1705FCA      vmaxps       xmm1, xmm1, xmm2
    C4E1705FCB      vmaxps       xmm1, xmm1, xmm3
    C4E1785FC4      vmaxps       xmm0, xmm0, xmm4
    C4E1785FC5      vmaxps       xmm0, xmm0, xmm5
    C4E1785FC1      vmaxps       xmm0, xmm0, xmm1
```